### PR TITLE
Upgrading IntelliJ from 2023.3.4 to 2023.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.3.4 to 2023.3.5
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Logshipper'
 # SemVer format -> https://semver.org
-pluginVersion = 3.2.4
+pluginVersion = 3.2.5
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -13,7 +13,7 @@ pluginUntilBuild = 233.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.3.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.3.5,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` as we declare application componenets:
 #   - `ConstantLogEntryTesterComponent`
@@ -26,7 +26,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.3.4
+platformVersion = 2023.3.5
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.3.4 to 2023.3.5

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661888/IntelliJ-IDEA-2023.3.5-233.14808.21-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.3.5 is out with the following improvements: 
<ul> 
 <li>We've fixed the issue causing erratic screen scaling on Linux. [<a href="https://youtrack.jetbrains.com/issue/IDEA-341318/">IDEA-341318</a>]</li> 
 <li>The <em>Project Errors</em> tab in the <em>Problems</em> tool window no longer erroneously continues to display issues that have already been resolved. [<a href="https://youtrack.jetbrains.com/issue/IDEA-343358/">IDEA-343358</a>]</li> 
 <li>The <em>Select None</em> button in the <em>Generate Constructor</em> dialog is responsive again and works as expected. [<a href="https://youtrack.jetbrains.com/issue/IDEA-340046/UI-buttons-problem">IDEA-340046</a>]</li> 
 <li>We've fixed the issue with Maven wrapper settings becoming invalid when installing or uninstalling language packs. [<a href="https://youtrack.jetbrains.com/issue/IDEA-338796/">IDEA-338796</a>]</li> 
 <li>The gutter icons once again display properly in GraphQL schema files. [<a href="https://youtrack.jetbrains.com/issue/IDEA-348051/">IDEA-348051</a>]</li> 
</ul> For more details, refer to our 
<a href="https://blog.jetbrains.com/idea/2024/03/intellij-idea-2023-3-5/">blog post</a>.
    