### PR TITLE
Upgrading IntelliJ from 2023.3.6 to 2024.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.3.6 to 2024.1.0
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,16 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Logshipper'
 # SemVer format -> https://semver.org
-pluginVersion = 3.2.6
+pluginVersion = 4.0.0
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 233
-pluginUntilBuild = 233.*
+pluginSinceBuild = 241
+pluginUntilBuild = 241.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.3.6,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` as we declare application componenets:
 #   - `ConstantLogEntryTesterComponent`
@@ -26,7 +26,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.3.6
+platformVersion = 2024.1
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/src/main/java/com/chriscarini/jetbrains/logshipper/logger/LogstashUtilFormatter.java
+++ b/src/main/java/com/chriscarini/jetbrains/logshipper/logger/LogstashUtilFormatter.java
@@ -7,7 +7,6 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.PermanentInstallationID;
 import com.intellij.openapi.application.ex.ApplicationInfoEx;
 import com.intellij.ui.LicensingFacade;
-import com.intellij.util.text.DateFormatUtil;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -18,6 +17,7 @@ import javax.json.JsonBuilderFactory;
 import javax.json.JsonObjectBuilder;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Properties;
@@ -179,7 +179,7 @@ public class LogstashUtilFormatter extends Formatter {
                 mdcBuilder.add("StrictVersion", appInfoEx.getStrictVersion());
                 mdcBuilder.add("VersionName", appInfoEx.getVersionName());
                 mdcBuilder.add("Build", appInfoEx.getBuild().asString());
-                mdcBuilder.add("BuildDate", DateFormatUtil.getIso8601Format().format(appInfoEx.getBuildDate().getTime()));
+                mdcBuilder.add("BuildDate", DateTimeFormatter.ISO_DATE_TIME.format(appInfoEx.getBuildDate().getTime().toInstant()));
             }
 
             final LicensingFacade licensingFacade = LicensingFacade.getInstance();
@@ -187,7 +187,7 @@ public class LogstashUtilFormatter extends Formatter {
                 mdcBuilder.add("LicensedToMessage", Objects.requireNonNullElse(licensingFacade.getLicensedToMessage(), ""));
                 mdcBuilder.add("LicenseRestrictionsMessages", String.join(";", licensingFacade.getLicenseRestrictionsMessages()));
                 mdcBuilder.add("isEvaluationLicense", Boolean.toString(licensingFacade.isEvaluationLicense()));
-                mdcBuilder.add("LicenseExpirationDate", licensingFacade.getLicenseExpirationDate() != null ? DateFormatUtil.getIso8601Format().format(licensingFacade.getLicenseExpirationDate()) : "Unknown");
+                mdcBuilder.add("LicenseExpirationDate", licensingFacade.getLicenseExpirationDate() != null ? DateTimeFormatter.ISO_DATE_TIME.format(licensingFacade.getLicenseExpirationDate().toInstant()) : "Unknown");
                 mdcBuilder.add("ConfirmationStamps", licensingFacade.confirmationStamps != null ? licensingFacade.confirmationStamps.toString() : "null");
             }
             return mdcBuilder;


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.3.6 to 2024.1.0

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661899/IntelliJ-IDEA-2024.1-241.14494.240-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.1 is now available with the following new features: 
<ul> 
 <li>Full line code completion</li> 
 <li>Java 22 support</li> 
 <li>New terminal (Beta)</li> 
 <li>Sticky lines in the editor</li> 
</ul> Visit our 
<a href="https://www.jetbrains.com/idea/whatsnew/">What's New page</a> or watch 
<a href="https://youtu.be/FuvoOm4TIxE">this video</a> to learn about these and other improvements.
    