### PR TITLE
Upgrading IntelliJ from 2024.1.2 to 2024.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.1.2 to 2024.1.3
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Logshipper'
 # SemVer format -> https://semver.org
-pluginVersion = 4.0.2
+pluginVersion = 4.0.3
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -13,7 +13,7 @@ pluginUntilBuild = 241.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.1.2,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.1.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` as we declare application componenets:
 #   - `ConstantLogEntryTesterComponent`
@@ -26,7 +26,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.1.2
+platformVersion = 2024.1.3
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.1.2 to 2024.1.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661991/IntelliJ-IDEA-2024.1.3-241.17890.1-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.1.3 is out with the following improvements: 
<ul> 
 <li>Fixed security issue related to JetBrains GitHub Plugin.<a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-37051"> [CVE-2024-37051]<br></a>For more details, please refer to the <a href="https://blog.jetbrains.com/security/2024/06/updates-for-security-issue-affecting-intellij-based-ides-2023-1-and-github-plugin/">blog post</a>.</li> 
 <li>PlantUML diagrams in Markdown files are correctly rendered again. [<a href="https://youtrack.jetbrains.com/issue/IJPL-90975/">IJPL-90975</a>]</li> 
 <li>When the <em>diff</em> view is opened in an editor tab, it no longer expands uncontrollably when using a split view. [<a href="https://youtrack.jetbrains.com/issue/IJPL-99522/">IJPL-99522</a>]</li> 
 <li>Search results for <em>Find in project files<strong> </strong></em>are once again updated accurately after the source code is edited. [<a href="https://youtrack.jetbrains.com/issue/IJPL-45184/">IJPL-45184</a>]</li> 
 <li>The IDE accurately provides code highlighting and <em>Find Usages</em> results in projects located on APFS case-sensitive disks. [<a href="https://youtrack.jetbrains.com/issue/IDEA-290373/">IDEA-290373</a>]</li> 
</ul> For more fixed issues and improvements, please refer to this 
<a href="https://blog.jetbrains.com/idea/2024/06/intellij-idea-2024-1-3/">blog post</a>.
    