### PR TITLE
Upgrading IntelliJ from 2024.1.3 to 2024.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.1.3 to 2024.1.4
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Logshipper'
 # SemVer format -> https://semver.org
-pluginVersion = 4.0.3
+pluginVersion = 4.0.4
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -13,7 +13,7 @@ pluginUntilBuild = 241.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.1.3,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.1.4,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` as we declare application componenets:
 #   - `ConstantLogEntryTesterComponent`
@@ -26,7 +26,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.1.3
+platformVersion = 2024.1.4
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.1.3 to 2024.1.4

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662016/IntelliJ-IDEA-2024.1.4-241.18034.62-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.1.4 is out with the following improvements: 
<ul> 
 <li>Code validation no longer produces incorrect code highlighting caused by freezes while reevaluating inspections. [<a href="https://youtrack.jetbrains.com/issue/IJPL-28967/">IJPL-28967</a>]</li> 
 <li>We fixed the issue causing the IDE to lag when editing code. [<a href="https://youtrack.jetbrains.com/issue/IJPL-149640/">IJPL-149640</a>, <a href="https://youtrack.jetbrains.com/issue/IJPL-156086/">IJPL-156086</a>]</li> 
 <li>The <em>Unknown HTTP header</em> inspection once again loads settings from the inspection profile correctly. [<a href="https://youtrack.jetbrains.com/issue/IJPL-65369/">IJPL-65369</a>]</li> 
 <li>The IDE no longer fails to perform operations, citing the <em>Too complex, sorry</em> message. [<a href="https://youtrack.jetbrains.com/issue/IJPL-1116/">IJPL-1116</a>]</li> 
 <li>Updating plugins from the <em>Welcome </em>screen now works as expected again. [<a href="https://youtrack.jetbrains.com/issue/IJPL-6076/">IJPL-6076</a>]</li> 
</ul> Get more details in our 
<a href="https://blog.jetbrains.com/idea/2024/06/intellij-idea-2024-1-4/">blog post</a>.
    