### PR TITLE
Upgrading IntelliJ from 2024.3.1.1 to 2024.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.3.1.1 to 2024.3.2
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 ### Added
+- Added more detailed logging for Logshipper log handler is added/removed to/from the root logger.
 
 ### Changed
 - Upgrading IntelliJ from 2024.3.1.1 to 2024.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 - Upgrading IntelliJ from 2024.3.1.1 to 2024.3.2
+- Use `String.format()` instead of `IdeBundle.message()` in logs, since the latter causes recursion leading to `StackOverflowError`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Deprecated
 
 ### Removed
+- Remove call to `@ApiStatus.Internal` method `ShutDownTracker.getInstance().registerShutdownTask()`.
 
 ### Fixed
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/logshipper-intellij-plugin
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 4.2.2
+pluginVersion = 4.2.3
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 243.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.3.1.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.3.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` as we declare application components:
 #   - `ConstantLogEntryTesterComponent`
@@ -38,7 +38,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2024.3.1.1
+platformVersion = 2024.3.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,10 +19,7 @@ pluginUntilBuild = 243.*
 # See https://jb.gg/intellij-platform-builds-list for available build versions
 pluginVerifierIdeVersions = 2024.3.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
-# Exclude `NOT_DYNAMIC` as we declare application components:
-#   - `ConstantLogEntryTesterComponent`
-#   - `LogstashLayoutAppenderComponent`
-pluginVerifierExcludeFailureLevels = NOT_DYNAMIC
+pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
 # Used to mute (ignore) a comma-seperated list of plugin problems.
 pluginVerifierMutePluginProblems =

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,9 +22,7 @@ pluginVerifierIdeVersions = 2024.3.2,LATEST-EAP-SNAPSHOT
 # Exclude `NOT_DYNAMIC` as we declare application components:
 #   - `ConstantLogEntryTesterComponent`
 #   - `LogstashLayoutAppenderComponent`
-# Exclude `INTERNAL_API_USAGES` - In `LogstashLayoutAppenderService` we use `ShutDownTracker`, which is marked as being low-level. We want to tap into the shutdown 
-#                                 process at the lowest level to ensure we're not cleaning up resources before the application is done with them (and missing logs).
-pluginVerifierExcludeFailureLevels = NOT_DYNAMIC, INTERNAL_API_USAGES
+pluginVerifierExcludeFailureLevels = NOT_DYNAMIC
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
 # Used to mute (ignore) a comma-seperated list of plugin problems.
 pluginVerifierMutePluginProblems =

--- a/src/main/java/com/chriscarini/jetbrains/logshipper/logger/LogstashUtilFormatter.java
+++ b/src/main/java/com/chriscarini/jetbrains/logshipper/logger/LogstashUtilFormatter.java
@@ -169,8 +169,13 @@ public class LogstashUtilFormatter extends Formatter {
             final JsonObjectBuilder mdcBuilder = BUILDER.createObjectBuilder();
 
             mdcBuilder.add("PermanentInstallationID", PermanentInstallationID.get())
-                    .add("JREInformation", IdeBundle.message("about.box.jre", properties.getProperty("java.runtime.version", properties.getProperty("java.version", "unknown")), properties.getProperty("os.arch", "")))
-                    .add("JVMInformation", IdeBundle.message("about.box.vm", properties.getProperty("java.vm.name", "unknown"), properties.getProperty("java.vendor", "unknown")));
+                // Use `String.format()` instead of `IdeBundle.message()` since `DynamicBundle.getBundle()` started logging as of 
+                // commit https://github.com/JetBrains/intellij-community/commit/69f79762252518dbc7c1535d466324a5cf311ad3, which 
+                // causes a recursive loop, leading to StackOverflowError.
+                //    .add("JREInformation", IdeBundle.message("about.box.jre", properties.getProperty("java.runtime.version", properties.getProperty("java.version", "unknown")), properties.getProperty("os.arch", "")))
+                    .add("JREInformation", String.format("Runtime version: %s %s", properties.getProperty("java.runtime.version", properties.getProperty("java.version", "unknown")), properties.getProperty("os.arch", "")))
+                //    .add("JVMInformation", IdeBundle.message("about.box.vm", properties.getProperty("java.vm.name", "unknown"), properties.getProperty("java.vendor", "unknown")));
+                    .add("JVMInformation", String.format("VM: %s by %s", properties.getProperty("java.vm.name", "unknown"), properties.getProperty("java.vendor", "unknown")));
 
             if (!ApplicationManager.getApplication().isDisposed()) {
                 final ApplicationInfoEx appInfoEx = ApplicationInfoEx.getInstanceEx();


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.3.1.1 to 2024.3.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662349/IntelliJ-IDEA-2024.3.2-243.23654.117-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.3.2 is out! This release includes the following improvements: 
<ul>
 <li>Using certain third-party plugins no longer causes the font settings to reset to default. [<a href="https://youtrack.jetbrains.com/issue/IJPL-157487">IJPL-157487</a>]</li>
 <li>It's again possible to compile Java 7 projects with Javac version 7. [<a href="https://youtrack.jetbrains.com/issue/IDEA-361854">IDEA-361854</a>]</li>
 <li>JPA Buddy's <em>New Association Attribute</em> dialog option for @OneToMany once again works as expected. [<a href="https://youtrack.jetbrains.com/issue/IDEA-359970">IDEA-359970</a>]</li>
</ul> Get more details from our <a href="https://blog.jetbrains.com/idea/2025/01/intellij-idea-2024-3-2/">blog post</a>.
    