### PR TITLE
Upgrading IntelliJ from 2025.1.3 to 2025.1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2025.1.3 to 2025.1.4.1
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/logshipper-intellij-plugin
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 5.0.2
+pluginVersion = 5.0.3
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 251.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2025.1.3,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2025.1.4.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -33,7 +33,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2025.1.3
+platformVersion = 2025.1.4.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.1.3 to 2025.1.4.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662478/IntelliJ-IDEA-2025.1.4-251.27812.49-build-Release-Notes

# What's New?
IntelliJ IDEA 2025.1.4 is available! Here are the most notable updates: 
<ul>
 <li>A compatibility issue with the Junie plugin has been fixed. [<a href="https://youtrack.jetbrains.com/issue/JUNIE-429">JUNIE-429</a>]</li>
 <li>Closing labels in Dart have been updated for better usability and now appear as inlay hints, with improved configuration options. [<a href="https://youtrack.jetbrains.com/issue/IDEA-289260/">IDEA-289260</a>]</li>
 <li>The <em>Final declaration can't be overridden at runtime</em> warning no longer falsely appears for @Configuration classes with proxyBeanMethods. [<a href="https://youtrack.jetbrains.com/issue/IDEA-304648/">IDEA-304648</a>]</li>
 <li>It is once again possible to override variables from imported <code>.http</code> files in the HTTP Client. [<a href="https://youtrack.jetbrains.com/issue/IJPL-190688/">IJPL-190688</a>]</li>
</ul> Get more details from our <a href="https://blog.jetbrains.com/idea/2025/07/intellij-idea-2025-1-4/">blog post</a>.
    